### PR TITLE
Fix: Make Profile Page responsive

### DIFF
--- a/app/resume/[name]/page.tsx
+++ b/app/resume/[name]/page.tsx
@@ -9,9 +9,9 @@ const page = ({ params }: { params: { name: string } }) => {
   if (!user) return;
 
   return (
-    <div className="w-screen flex items-start justify-center">
+    <div className="w-screen sm:flex items-start justify-center">
       <Profile data={user} />
-      <div className="w-2/3 flex justify-center py-8">
+      <div className="w-[98vw]  md:w-2/3 flex justify-center py-8">
         <Resume user={params.name} />
       </div>
     </div>

--- a/components/sections/Profile.tsx
+++ b/components/sections/Profile.tsx
@@ -5,7 +5,7 @@ import { Info } from "@/lib/types";
 
 const Profile = ({ data }: { data: Info }) => {
   return (
-    <BackgroundBeamsWithCollision className="w-1/3 flex flex-col gap-4 items-start px-8 relative min-h-screen">
+    <BackgroundBeamsWithCollision className="md:w-1/3 flex flex-col gap-4 items-start px-8 relative h-auto md:min-h-screen">
       <div className="flex gap-2 items-end">
         <Image
           height="100"
@@ -15,10 +15,10 @@ const Profile = ({ data }: { data: Info }) => {
           className="h-24 w-24 rounded-full border-2 object-cover"
         />
         <div className="flex flex-col items-start">
-          <h1 className="bg-gradient-to-br from-slate-300 to-slate-500 bg-clip-text text-center text-3xl font-medium tracking-tight text-transparent md:text-4xl">
+          <h1 className="bg-gradient-to-br from-slate-300 to-slate-500 bg-clip-text text-center text-2xl sm:text-2xl font-medium tracking-tight text-transparent md:text-4xl">
             {data.name}
           </h1>
-          <p className="text-white/40 tracking-wider">
+          <p className="text-white/40 text-sm tracking-wider">
             {data.domain} developer at Ghaziabad
           </p>
         </div>

--- a/components/sections/Resume.tsx
+++ b/components/sections/Resume.tsx
@@ -25,7 +25,7 @@ const Resume = ({ user }: { user: string }) => {
   if (!resumeData) return;
 
   return (
-    <div className="md:flex grid gap-4 items-start mt-8 mb-16">
+    <div className="md:flex grid gap-4 px-4 md:px-0 items-start mt-8 mb-16">
       <div className="bg-white order-2 md:order-1 p-8 rounded-2xl shadow-lg max-w-full  md:max-w-3xl mx-auto text-black h-[calc(100vh-8rem)] overflow-y-scroll">
         <header className="mb-6">
           <h1 className="text-3xl font-bold">{resumeData.name}</h1>

--- a/components/sections/Resume.tsx
+++ b/components/sections/Resume.tsx
@@ -25,8 +25,8 @@ const Resume = ({ user }: { user: string }) => {
   if (!resumeData) return;
 
   return (
-    <div className="flex gap-4 items-start mt-8 mb-16">
-      <div className="bg-white p-8 rounded-2xl shadow-lg max-w-3xl mx-auto text-black h-[calc(100vh-8rem)] overflow-y-scroll">
+    <div className="md:flex grid gap-4 items-start mt-8 mb-16">
+      <div className="bg-white order-2 md:order-1 p-8 rounded-2xl shadow-lg max-w-full  md:max-w-3xl mx-auto text-black h-[calc(100vh-8rem)] overflow-y-scroll">
         <header className="mb-6">
           <h1 className="text-3xl font-bold">{resumeData.name}</h1>
           <p className="text-gray-600">{resumeData.location}</p>
@@ -136,9 +136,9 @@ const Resume = ({ user }: { user: string }) => {
           </ul>
         </section>
       </div>
-      <div className="flex flex-col gap-4 bg-gray-800/50 px-2 py-4 rounded-lg">
+      <div className=" w-[30vw] md:w-auto md:order-2 order-1 w-2xl flex justify-evenly md:flex-col gap-4 bg-gray-800/50 px-2 py-4 rounded-lg">
         <Download data={resumeData}  />
-        <div className="w-full bg-gray-500 h-px"></div>
+        <div className=" max-h-full w-px md:w-full bg-gray-500 md:h-px"></div>
         <Share name={resumeData.name} />
       </div>
     </div>

--- a/components/ui/background-beams-with-collision.tsx
+++ b/components/ui/background-beams-with-collision.tsx
@@ -123,7 +123,7 @@ export const BackgroundBeamsWithCollision = ({
     <div
       ref={parentRef}
       className={cn(
-        "min-h-[calc(100vh-3.5rem)] relative flex items-center w-full justify-center overflow-hidden",
+        "min-h-[calc(70vh-3.5rem)] md:min-h-[calc(100vh-3.5rem)] relative flex items-center w-full justify-center overflow-hidden",
         className
       )}
     >


### PR DESCRIPTION
## Fix Profile Page Responsiveness

### Description
This PR addresses the issue of the Profile page not being responsive on smaller screens. The following changes have been made to ensure a better user experience across different devices:

- Added media queries to handle different breakpoints (mobile, tablet, desktop).
- Adjusted flexbox and grid layouts to maintain proper alignment and spacing.
- Scaled images and text to fit smaller screen sizes without affecting readability.
- Resolved overflow and alignment issues on mobile devices.
- Tested the layout on various screen sizes to ensure consistency and responsiveness.

### Views
![Screenshot 2024-10-09 222946](https://github.com/user-attachments/assets/a78756fb-bdb5-40ff-9616-756e626c386a)
![Screenshot 2024-10-09 222957](https://github.com/user-attachments/assets/8bef78e9-7772-4915-a642-be80b6b0aa74)
![Screenshot 2024-10-09 223905](https://github.com/user-attachments/assets/c19baeea-53f1-4a51-bd9d-1c04488ae689)

### Linked Issue
Closes #14 
