### PR TITLE
#59 fix/remove-harcoded-developers-location

### DIFF
--- a/components/sections/Profile.tsx
+++ b/components/sections/Profile.tsx
@@ -19,7 +19,7 @@ const Profile = ({ data }: { data: Info }) => {
             {data.name}
           </h1>
           <p className="text-white/40 tracking-wider capitalize">
-            {data.domain} developer at Ghaziabad
+            {data.domain}
           </p>
         </div>
       </div>


### PR DESCRIPTION
Removed the hardcoded location from profile section
![image](https://github.com/user-attachments/assets/dfbfc10c-a06b-4109-8e4e-3249665c8e72)
