### PR TITLE
feat: #39 Add back button to resume and resume/[name] pages

### DIFF
--- a/app/resume/[name]/page.tsx
+++ b/app/resume/[name]/page.tsx
@@ -1,6 +1,8 @@
 import { info } from "@/app/_content/CardInfo";
 import Profile from "@/components/sections/Profile";
 import Resume from "@/components/sections/Resume";
+import BackButton from "@/components/ui/back-button";
+import Link from "next/link";
 import React from "react";
 
 const page = ({ params }: { params: { name: string } }) => {
@@ -9,12 +11,17 @@ const page = ({ params }: { params: { name: string } }) => {
   if (!user) return;
 
   return (
-    <div className="w-screen sm:flex items-start justify-center">
-      <Profile data={user} />
-      <div className="w-[98vw]  md:w-2/3 flex justify-center py-8">
-        <Resume user={params.name} />
+    <>
+      <Link href="/resume" className="fixed left-4 top-4 z-[9999] ">
+            <BackButton />
+      </Link>
+      <div className="w-screen sm:flex items-start justify-center">
+        <Profile data={user} />
+        <div className="w-[98vw]  md:w-2/3 flex justify-center py-8">
+          <Resume user={params.name} />
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -3,10 +3,15 @@ import { InfiniteMovingCards } from "@/components/ui/infinite-cards";
 import React from "react";
 import { info } from "../_content/CardInfo";
 import { TextRevealCard } from "@/components/ui/text-reveal-card";
+import BackButton from "@/components/ui/back-button";
+import Link from "next/link";
 
 const page = () => {
   return (
     <div>
+        <Link href="/" className="fixed left-4 top-4 z-[9999] ">
+          <BackButton />
+        </Link>
       <div className="min-h-screen rounded-md flex flex-col antialiased bg-white dark:bg-black dark:bg-grid-white/[0.05] items-center justify-center relative overflow-hidden">
         <InfiniteMovingCards data={info} direction="right" speed="fast" />
         <InfiniteMovingCards data={info} direction="left" speed="fast" />

--- a/components/icons/BackArrow.tsx
+++ b/components/icons/BackArrow.tsx
@@ -1,21 +1,21 @@
 import React from "react";
 
-const BackArrow = () => {
-    return (
-        <svg width="20px" height="20px" viewBox="0 0 1024.00 1024.00" fill="#FFFFFF" className="icon" version="1.1" xmlns="http://www.w3.org/2000/svg" stroke="#FFFFFF" strokeWidth="0.01024" transform="matrix(1, 0, 0, 1, 0, 0)rotate(0)" aria-label="Back-Arrow">
-
-            <g id="SVGRepo_bgCarrier" strokeWidth="0" />
-
-            <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round" stroke="#CCCCCC" strokeWidth="2.048" />
-
-            <g id="SVGRepo_iconCarrier">
-
-                <path d="M669.6 849.6c8.8 8 22.4 7.2 30.4-1.6s7.2-22.4-1.6-30.4l-309.6-280c-8-7.2-8-17.6 0-24.8l309.6-270.4c8.8-8 9.6-21.6 2.4-30.4-8-8.8-21.6-9.6-30.4-2.4L360.8 480.8c-27.2 24-28 64-0.8 88.8l309.6 280z" fill="" />
-
-            </g>
-
-        </svg>
+const BackArrow = () => (
+    <svg 
+        xmlns="http://www.w3.org/2000/svg" 
+        viewBox="0 0 24 24" 
+        width={20} 
+        height={20} 
+        color={"#ffffff"} 
+        fill={"none"}
+    >
+        <path 
+            d="M4.80823 9.44118L6.77353 7.46899C8.18956 6.04799 8.74462 5.28357 9.51139 5.55381C10.4675 5.89077 10.1528 8.01692 10.1528 8.73471C11.6393 8.73471 13.1848 8.60259 14.6502 8.87787C19.4874 9.78664 21 13.7153 21 18C19.6309 17.0302 18.2632 15.997 16.6177 15.5476C14.5636 14.9865 12.2696 15.2542 10.1528 15.2542C10.1528 15.972 10.4675 18.0982 9.51139 18.4351C8.64251 18.7413 8.18956 17.9409 6.77353 16.5199L4.80823 14.5477C3.60275 13.338 3 12.7332 3 11.9945C3 11.2558 3.60275 10.6509 4.80823 9.44118Z" 
+            stroke="currentColor" 
+            strokeWidth="1" 
+            strokeLinecap="round" 
+            strokeLinejoin="round" />
+    </svg>
     );
-};
 
 export default BackArrow;

--- a/components/icons/BackArrow.tsx
+++ b/components/icons/BackArrow.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const BackArrow = () => {
+    return (
+        <svg width="20px" height="20px" viewBox="0 0 1024.00 1024.00" fill="#FFFFFF" className="icon" version="1.1" xmlns="http://www.w3.org/2000/svg" stroke="#FFFFFF" strokeWidth="0.01024" transform="matrix(1, 0, 0, 1, 0, 0)rotate(0)" aria-label="Back-Arrow">
+
+            <g id="SVGRepo_bgCarrier" strokeWidth="0" />
+
+            <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round" stroke="#CCCCCC" strokeWidth="2.048" />
+
+            <g id="SVGRepo_iconCarrier">
+
+                <path d="M669.6 849.6c8.8 8 22.4 7.2 30.4-1.6s7.2-22.4-1.6-30.4l-309.6-280c-8-7.2-8-17.6 0-24.8l309.6-270.4c8.8-8 9.6-21.6 2.4-30.4-8-8.8-21.6-9.6-30.4-2.4L360.8 480.8c-27.2 24-28 64-0.8 88.8l309.6 280z" fill="" />
+
+            </g>
+
+        </svg>
+    );
+};
+
+export default BackArrow;

--- a/components/ui/back-button.tsx
+++ b/components/ui/back-button.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import BackArrow from "../icons/BackArrow";
+
+const BackButton = () => {
+  return (
+    <button className="bg-slate-800 no-underline group cursor-pointer relative shadow-2xl shadow-zinc-900 rounded-full p-px leading-6 inline-block">
+      <span className="absolute inset-0 overflow-hidden rounded-full">
+        <span className="absolute inset-0 rounded-full bg-[image:radial-gradient(75%_100%_at_50%_0%,rgba(56,189,248,0.6)_0%,rgba(56,189,248,0)_75%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"></span>
+      </span>
+      <div className="relative flex space-x-2 items-center z-10 rounded-full bg-zinc-950 py-1 px-1 ring-1 ring-white/10 ">
+        <span className="hover:line-through"><BackArrow /></span>
+      </div>
+    </button>
+  );
+};
+
+export default BackButton;


### PR DESCRIPTION
Description:
This PR solves issue #39 by adding a back button to the resume and resume/[name] pages, allowing users to navigate to the previous page.

Changes:
I added a button to both the resume and individual resume pages.
The button enables users to return to the previous page easily.

![Screenshot 2024-10-11 005608](https://github.com/user-attachments/assets/a35ae79c-6d96-42ae-bf43-eef4b7400ada)

![Screenshot 2024-10-11 005651](https://github.com/user-attachments/assets/48280d45-d713-44a9-8196-6f46f615f1ca)
